### PR TITLE
fix(local): prevent worker counter leaks when session is released first

### DIFF
--- a/local/local.go
+++ b/local/local.go
@@ -15,6 +15,13 @@ func init() {
 	dsession.Register("local", NewLocalSessionPool)
 }
 
+// workerMapping stores the session key and organization ID for a worker
+// This allows proper cleanup of all counters even if the session is released first
+type workerMapping struct {
+	sessionKey     string
+	organizationID string
+}
+
 // LocalSessionPool is a local in-memory implementation of the session pool
 type LocalSessionPool struct {
 	logger *zap.Logger
@@ -34,7 +41,7 @@ type LocalSessionPool struct {
 	traceIDSessions      map[string]int64
 	organizationSessions map[string]int64
 	orgWorkers           map[string]int64
-	workerToSession      map[string]string
+	workerToSession      map[string]workerMapping
 }
 
 // NewLocalSessionPool creates a new local session pool
@@ -55,7 +62,7 @@ func NewLocalSessionPool(config string, logger *zap.Logger) (dsession.SessionPoo
 		traceIDSessions:      make(map[string]int64),
 		organizationSessions: make(map[string]int64),
 		orgWorkers:           make(map[string]int64),
-		workerToSession:      make(map[string]string),
+		workerToSession:      make(map[string]workerMapping),
 	}
 
 	// Parse URL parameters for configuration

--- a/local/workers.go
+++ b/local/workers.go
@@ -75,7 +75,10 @@ func (p *LocalSessionPool) GetWorker(
 	workerKey := fmt.Sprintf("%s-w%04d", requestKey, sessionWorkerNum)
 
 	// Track the worker-to-session mapping and update user worker count
-	p.workerToSession[workerKey] = requestKey
+	p.workerToSession[workerKey] = workerMapping{
+		sessionKey:     requestKey,
+		organizationID: sess.organizationID,
+	}
 	p.orgWorkers[sess.organizationID]++
 
 	p.logger.Debug("worker borrowed",
@@ -98,7 +101,7 @@ func (p *LocalSessionPool) ReleaseWorker(workerKey string) {
 	defer p.mu.Unlock()
 
 	// Find the session this worker belongs to
-	sessionKey, exists := p.workerToSession[workerKey]
+	mapping, exists := p.workerToSession[workerKey]
 	if !exists {
 		p.logger.Warn("releasing unknown worker",
 			zap.String("worker_key", workerKey))
@@ -108,30 +111,34 @@ func (p *LocalSessionPool) ReleaseWorker(workerKey string) {
 	// Remove the worker from the mapping
 	delete(p.workerToSession, workerKey)
 
-	// Find the session and decrement its worker count
-	sess, sessionExists := p.borrowedSessions[sessionKey]
-	if !sessionExists {
-		p.logger.Warn("worker belongs to unknown session",
-			zap.String("worker_key", workerKey),
-			zap.String("session_key", sessionKey))
-		return
-	}
-
-	// Decrement counters
+	// Always decrement the global worker counter
 	globalWorkers := p.workerCounter.Add(-1)
-	sessionWorkers := sess.workers.Add(-1)
 
-	// Decrement user worker count
-	if count, ok := p.orgWorkers[sess.organizationID]; ok && count > 0 {
-		p.orgWorkers[sess.organizationID]--
-		if p.orgWorkers[sess.organizationID] == 0 {
-			delete(p.orgWorkers, sess.organizationID)
+	// Always decrement org workers using the stored organizationID
+	if count, ok := p.orgWorkers[mapping.organizationID]; ok && count > 0 {
+		p.orgWorkers[mapping.organizationID]--
+		if p.orgWorkers[mapping.organizationID] == 0 {
+			delete(p.orgWorkers, mapping.organizationID)
 		}
 	}
 
+	// Find the session and decrement its worker count (if session still exists)
+	sess, sessionExists := p.borrowedSessions[mapping.sessionKey]
+	if !sessionExists {
+		// Session was already released, but we've already decremented global and org counters above
+		p.logger.Warn("worker released but session already gone",
+			zap.String("worker_key", workerKey),
+			zap.String("session_key", mapping.sessionKey),
+			zap.Int64("remaining_global_workers", globalWorkers))
+		return
+	}
+
+	// Decrement session-specific counter
+	sessionWorkers := sess.workers.Add(-1)
+
 	p.logger.Debug("worker released",
 		zap.String("worker_key", workerKey),
-		zap.String("session_key", sessionKey),
+		zap.String("session_key", mapping.sessionKey),
 		zap.Int64("remaining_session_workers", sessionWorkers),
 		zap.Int64("remaining_global_workers", globalWorkers))
 }

--- a/local/workers_test.go
+++ b/local/workers_test.go
@@ -34,12 +34,13 @@ func TestLocalSessionPool_GetWorker(t *testing.T) {
 		// Check that worker was tracked
 		localPool := pool.(*LocalSessionPool)
 		localPool.mu.RLock()
-		mappedSessionKey, exists := localPool.workerToSession[workerKey]
+		mapping, exists := localPool.workerToSession[workerKey]
 		orgWorkers := localPool.orgWorkers["org1"]
 		localPool.mu.RUnlock()
 
 		assert.True(t, exists)
-		assert.Equal(t, sessionKey, mappedSessionKey)
+		assert.Equal(t, sessionKey, mapping.sessionKey)
+		assert.Equal(t, "org1", mapping.organizationID)
 		assert.Equal(t, int64(1), orgWorkers)
 	})
 


### PR DESCRIPTION
Fixes #1

When a session is released before all its workers are returned, the workerCounter and orgWorkers counters were not decremented, causing a progressive leak that eventually blocks all new worker allocations.

Root cause: ReleaseWorker() returned early when the session was gone, without decrementing the global and per-org counters.

Fix:
- Store organizationID alongside sessionKey in workerToSession mapping
- Always decrement workerCounter and orgWorkers when releasing a worker
- Only skip session-specific counter if session is already gone

This prevents the parallelism degradation where tier1 starts with high CPU usage (many workers) but progressively drops to near-zero as the counters become artificially inflated.

Symptoms fixed:
- 'releasing unknown worker' warnings
- Gradual decrease in active workers over time
- CPU usage dropping from 80% to 5% over several hours