### PR TITLE
Fix worker counter leak from workerKey reuse

### DIFF
--- a/local/session.go
+++ b/local/session.go
@@ -18,6 +18,7 @@ type sessionInfo struct {
 	borrowedAt     time.Time
 	serviceName    string
 	workers        atomic.Int64
+	workerSeqID    atomic.Uint64
 }
 
 // Get borrows a session from the local pool

--- a/local/workers.go
+++ b/local/workers.go
@@ -71,8 +71,7 @@ func (p *LocalSessionPool) GetWorker(
 		return "", dsession.ErrWorkersLimitExceeded
 	}
 
-	// Generate worker key
-	workerKey := fmt.Sprintf("%s-w%04d", requestKey, sessionWorkerNum)
+	workerKey := fmt.Sprintf("%s-w%d", requestKey, sess.workerSeqID.Add(1))
 
 	// Track the worker-to-session mapping and update user worker count
 	p.workerToSession[workerKey] = requestKey


### PR DESCRIPTION
GetWorker generated workerKey from the cycling sess.workers count (e.g. "session-1-w0012"). When workers returned out of order, the count cycled and new Borrows reused the same key as still-active workers. The later Return for the original worker then cleared the new worker's workerToSession entry; the new worker's eventual Return found nothing to release, so its decrement was skipped and the counter leaked until the pool filled.

Use a monotonic per-session seq ID for the workerKey suffix so two borrows always get distinct keys.